### PR TITLE
Add an issue template for planning developer meetings.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Community Support
+    url: https://github.com/queens-py/queens/discussions
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/developer-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/developer-meeting.yml
@@ -1,0 +1,89 @@
+name: Developer Meeting
+description: Template for scheduling and documenting developer meetings.
+title: "Meeting on dd.mm.yyyy"
+labels: ["meeting type::developer"]
+body:
+  - type: textarea
+    id: meeting_intro
+    attributes:
+      label: Developer Meeting
+      description: Short summary shown in the final issue
+      value: |
+        This issue documents a regular developer meeting, including participants, agenda, action items, and minutes.
+
+  - type: textarea
+    id: zoom_meeting
+    attributes:
+      label: Zoom
+      value: |
+        We typically meet online via Zoom.
+        Any QUEENS contributor is welcome to join. 
+        If you are interested, please join our Slack workspace or contact a maintainer to receive the link.
+
+  - type: input
+    id: date
+    attributes:
+      label: Date
+      description: Date of the meeting in dd.mm.yyyy format
+      placeholder: dd.mm.yyyy
+    validations:
+      required: true
+
+  - type: input
+    id: time
+    attributes:
+      label: Time
+      description: Time of the meeting (e.g., 13:00 (GMT+1))
+      placeholder: "add time of meeting here"
+      value: "13:00 (GMT+1)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: participants
+    attributes:
+      label: Participants
+      description: List regular participants. Strike through (~~) names if not attending. Add yours if missing.
+      placeholder: "@ mention all planned participants here"
+      value: "@sbrandstaeter\n@gilrrei\n@maxdinkel\n@leahaeusel"
+    validations:
+      required: true
+
+  - type: input
+    id: host
+    attributes:
+      label: Host
+      description: GitHub handle of the meeting host
+      placeholder: "@ mention the host here"
+      value: "@sbrandstaeter"
+    validations:
+      required: true
+
+  - type: input
+    id: scribe
+    attributes:
+      label: Scribe
+      description: GitHub handle of the person taking notes
+      placeholder: "@ mention the scribe here"
+      value: "@gilrrei"
+    validations:
+      required: true
+
+  - type: textarea
+    id: agenda
+    attributes:
+      label: Agenda
+      description: Add agenda items here.
+      value: "Adapt the agenda here directly or comment points you would like to add below.\n1. Review **Action Items** from the previous meeting"
+
+  - type: textarea
+    id: action_items
+    attributes:
+      label: Action Items
+      description: Use this section during the meeting to track tasks. Mention responsible members.
+
+  - type: textarea
+    id: minutes
+    attributes:
+      label: Meeting Minutes
+      description: Add notes and summaries from the meeting here.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# queens-meetings
-This repository is used to manage, organize, and archive meetings and related documentation for the coordination of the open-source software project [QUEENS](https://github.com/queens-py/queens).
+### QUEENS Meetings
+
+This repository is used to manage, organize, and archive meetings and related documentation for the coordination of the [QUEENS](https://github.com/queens-py/queens) open-source software project.
+
+### Meeting Schedule
+
+We currently hold the following regular meetings:
+- **Bi-weekly Developer Meeting**: Fridays at 13:00 (GMT+1), lasting 60 minutes  
+- **Weekly Standup**: Mondays at 10:00 (GMT+1), lasting 10 minutes
+
+For exact dates of upcoming developer meetings, please refer to the list of [GitHub issues](https://github.com/queens-py/queens-meetings/issues).
+
+### How to Join
+
+All [QUEENS contributors](https://github.com/queens-py/queens/blob/main/CONTRIBUTING.md) are welcome to participate in the meetings.  
+To receive a link to the online meetings, please join our Slack workspace or contact a [project maintainer](https://www.queens-py.org/community/).


### PR DESCRIPTION
I guess it would make sense to rename them to contributor meetings?