### PR TITLE
Add  agenda to check if recent changes need action

### DIFF
--- a/.github/ISSUE_TEMPLATE/developer-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/developer-meeting.yml
@@ -74,7 +74,7 @@ body:
     attributes:
       label: Agenda
       description: Add agenda items here.
-      value: "Adapt the agenda here directly or comment points you would like to add below.\n1. Review **Action Items** from the previous meeting"
+      value: "Adapt the agenda here directly or comment points you would like to add below.\n1. Review **Action Items** from the previous meeting\n2. Check for changes that should be added to the changelog or announced to the community."
 
   - type: textarea
     id: action_items


### PR DESCRIPTION
As decided in the last meeting (#5 ) we want to check at each meeting wether any recent changes to QUEENS should be added to the changelog and/ or should be announced to the community.