### PR TITLE
Update meeting schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository is used to manage, organize, and archive meetings and related do
 
 ### Meeting Schedule
 
-We currently hold the following regular meetings:
-- **Bi-weekly Developer Meeting**: Fridays at 13:00 (GMT+1), lasting 60 minutes  
-- **Weekly Standup**: Mondays at 10:00 (GMT+1), lasting 10 minutes
+We currently hold the following regular, alternating meetings:
+- **Bi-weekly Developer Meeting**: Mondays at 13:00 (GMT+1), lasting 60 minutes  
+- **Bi-weekly Standup**: Mondays at 13:00 (GMT+1), lasting 10 minutes
 
 For exact dates of upcoming developer meetings, please refer to the list of [GitHub issues](https://github.com/queens-py/queens-meetings/issues).
 


### PR DESCRIPTION
To avoid having qsubs the Monday after a developer meeting, we have decided in today's developer meeting to only hold the qsub bi-weekly from now on (next will be on 22.09.2025) and to move both meetings to Monday at 13:00.

So, from now on, we will alternate between qsubs and developer meetings on Mondays. Next week will be meeting-free since we just had the developer meeting today.