### PR TITLE
add new developer meeting label

### DIFF
--- a/.github/ISSUE_TEMPLATE/developer-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/developer-meeting.yml
@@ -1,7 +1,7 @@
 name: Developer Meeting
 description: Template for scheduling and documenting developer meetings.
 title: "Meeting on dd.mm.yyyy"
-labels: ["meeting type::developer"]
+labels: ["developer meeting"]
 body:
   - type: textarea
     id: meeting_intro


### PR DESCRIPTION
Add the new developer meeting label (in QUEENS color) to the meeting issue template. The old one didn't work and github does not like scoped labels :/