### PR TITLE
Add dependency update section to meeting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/developer-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/developer-meeting.yml
@@ -74,7 +74,7 @@ body:
     attributes:
       label: Agenda
       description: Add agenda items here.
-      value: "Adapt the agenda here directly or comment points you would like to add below.\n1. Review **Action Items** from the previous meeting\n2. Check for changes that should be added to the changelog or announced to the community.\n3. Assign a developer who will be responsible for updateing the dependencies this month."
+      value: "Adapt the agenda here directly or comment points you would like to add below.\n1. Review **Action Items** from the previous meeting\n2. Check for changes that should be added to the changelog or announced to the community.\n3. Assign a developer who will be responsible for updating the dependencies this month."
 
   - type: textarea
     id: action_items

--- a/.github/ISSUE_TEMPLATE/developer-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/developer-meeting.yml
@@ -83,6 +83,12 @@ body:
       description: Use this section during the meeting to track tasks. Mention responsible members.
 
   - type: textarea
+    id: dependency_update
+    attributes:
+      label: Dependency Update
+      description: Use this section during the meeting to track who is responsible for updating the dependencies this month. Mention responsible members.
+
+  - type: textarea
     id: minutes
     attributes:
       label: Meeting Minutes

--- a/.github/ISSUE_TEMPLATE/developer-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/developer-meeting.yml
@@ -74,19 +74,13 @@ body:
     attributes:
       label: Agenda
       description: Add agenda items here.
-      value: "Adapt the agenda here directly or comment points you would like to add below.\n1. Review **Action Items** from the previous meeting\n2. Check for changes that should be added to the changelog or announced to the community."
+      value: "Adapt the agenda here directly or comment points you would like to add below.\n1. Review **Action Items** from the previous meeting\n2. Check for changes that should be added to the changelog or announced to the community.\n3. Assign a developer who will be responsible for updateing the dependencies this month."
 
   - type: textarea
     id: action_items
     attributes:
       label: Action Items
       description: Use this section during the meeting to track tasks. Mention responsible members.
-
-  - type: textarea
-    id: dependency_update
-    attributes:
-      label: Dependency Update
-      description: Use this section during the meeting to track who is responsible for updating the dependencies this month. Mention responsible members.
 
   - type: textarea
     id: minutes


### PR DESCRIPTION
Added a section to track dependency updates during meetings.

Since I've never modified this template before, I would appreciate feedback if this is correct and whether you envisioned it that way 😊 